### PR TITLE
Ignore _mapkit_hasPanoramaID until Apple provides an implementation

### DIFF
--- a/src/dsl/UIQuery.m
+++ b/src/dsl/UIQuery.m
@@ -322,7 +322,11 @@
 			}
 			
 			SEL selector = NSSelectorFromString(key);
-			if ([object respondsToSelector:selector]) {
+            
+            // Apple declares but does not implement _mapkit_hasPanoramaID, therefore
+            // we ignore _mapkit_hasPanoramaID until Apple provides an implementation
+            BOOL mapkit_hasPanoramaID = (strcmp(propertyName, "_mapkit_hasPanoramaID") == 0);
+            if ([object respondsToSelector:selector] && mapkit_hasPanoramaID == NO) {
 				NSMethodSignature *sig = [object methodSignatureForSelector:selector];
 				//NSLog(@"sig = %@", sig);
 				NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];


### PR DESCRIPTION
Using the suggested NSObject category solution, does not seem to work under Xcode 4.0.1 and iOS-4.3

This work-around is to ignore invoking _mapkit_hasPanoramaID, when it is encountered by UIQuery.  Later when Apple provides the missing implementation, then this should be removed at that time.
