### PR TITLE
Frank additions

### DIFF
--- a/Private Headers/GraphicsServices/GSBase.h
+++ b/Private Headers/GraphicsServices/GSBase.h
@@ -1,0 +1,50 @@
+/*
+
+FILE_NAME ... DESCRIPTION
+ 
+Copyright (c) 2009, KennyTM~
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the KennyTM~ nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+#ifndef GSBASE_H
+#define GSBASE_H
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+	void GSLog(CFStringRef format, ...);
+	void GSInitialize();
+	
+#if __cplusplus
+}
+#endif
+
+#endif
+

--- a/Private Headers/GraphicsServices/GSCapability.h
+++ b/Private Headers/GraphicsServices/GSCapability.h
@@ -1,0 +1,165 @@
+/*
+
+GSCapability.h ... Graphics Service Capability.
+ 
+Copyright (c) 2009, KennyTM~
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the KennyTM~ nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+#ifndef GSCAPABILITY_H
+#define GSCAPABILITY_H
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Availability2.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+	/*! @brief Get the raw value of a key in the capability plist.
+	 The capability plist can be read from a shared memory region named "GSCapability"
+	 */
+	CFPropertyListRef _getCapability(CFStringRef capability);
+	
+	CFStringRef GSGetLocalizedDeviceName();	///< Get the localized device name (which is the "device-name-localized" capability).
+	CFStringRef GSGetDeviceName();	///< Get the device name (which is the "device-name" capability).
+	Boolean GSSystemHasCapability(CFStringRef capability);	///< Check if the system has the specified capability.
+	
+	
+	Boolean GSSystemCanTakePhoto();	///< Returns if the device can take photos (i.e. have "still-camera" but not "cameraRestriction" capabilities).
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	Boolean GSSystemHasTelephonyCapability();	///< Returns if the device has "telephony" capability.
+#else
+	Boolean GSSystemGetCellularDataCapability(void);	///< Returns if the device has "cellular-data" capability.
+	Boolean GSSystemGetTelephonyCapability(void);	///< Returns if the device has "telephony" capability.
+#endif
+	
+	/// If the capability is a dictionary (e.g. the "screen-dimensions" capability), copy the value of a key in that dictionary.
+	CFPropertyListRef GSSystemCopySubcapability(CFStringRef capability, CFStringRef subcapability);
+	CFPropertyListRef GSSystemCopyCapability(CFStringRef capability);	///< Copy the value of a capability.
+	
+	extern CFStringRef kGSCapabilityChangedNotification;
+
+	extern CFStringRef kGSCameraRestriction;
+	extern CFStringRef kGSInAppPurchasesRestriction;
+	extern CFStringRef kGSVolumeLimitRestriction;
+
+	extern CFStringRef kGSDeviceNameString;
+	extern CFStringRef kGSLocalizedDeviceNameString;
+
+	extern CFStringRef kGSTelephonyMaximumGeneration;
+	
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_1
+	extern CFStringRef kGSARMV6ExecutionCapability;
+	extern CFStringRef kGSARMV7ExecutionCapability;
+#endif
+	extern CFStringRef kGSAccelerometerCapability;
+	extern CFStringRef kGSAccessibilityCapability;
+	extern CFStringRef kGSAppleInternalInstallCapability;
+	extern CFStringRef kGSApplicationInstallationCapability;
+	extern CFStringRef kGSAutoFocusCameraCapability;
+	extern CFStringRef kGSBluetoothCapability;
+	extern CFStringRef kGSCameraCapability;
+	extern CFStringRef kGSDelaySleepForHeadsetClickCapability;
+	extern CFStringRef kGSDisplayFCCLogosViaSoftwareCapability;
+	extern CFStringRef kGSDisplayIdentifiersCapability;
+	extern CFStringRef kGSEncodeAACCapability;
+	extern CFStringRef kGSEncryptedDataPartitionCapability;
+	extern CFStringRef kGSExplicitContentRestriction;
+	extern CFStringRef kGSGPSCapability;
+	extern CFStringRef kGSGasGaugeBatteryCapability;
+	extern CFStringRef kGSGreenTeaDeviceCapability;
+	extern CFStringRef kGSHasAllFeaturesCapability;
+	extern CFStringRef kGSInternationalSettingsCapability;
+	extern CFStringRef kGSLaunchApplicationsWhileAnimatingCapability;
+	extern CFStringRef kGSLoadThumbnailsWhileScrollingCapability;
+	extern CFStringRef kGSLocationServicesCapability;
+	extern CFStringRef kGSMMSCapability;
+	extern CFStringRef kGSMagnetometerCapability;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_1
+	extern CFStringRef kGSMarketingNameString;
+#endif
+	extern CFStringRef kGSMicrophoneCapability;
+	extern CFStringRef kGSNikeIpodCapability;
+	extern CFStringRef kGSNotGreenTeaDeviceCapability;
+	extern CFStringRef kGSOpenGLES1Capability;
+	extern CFStringRef kGSOpenGLES2Capability;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_1
+	extern CFStringRef kGSPeer2PeerCapability;
+#endif
+	extern CFStringRef kGSPiezoClickerCapability;
+	extern CFStringRef kGSPlatformStandAloneContactsCapability;
+	extern CFStringRef kGSProximitySensorCapability;
+	extern CFStringRef kGSRingerSwitchCapability;
+	extern CFStringRef kGSSMSCapability;
+	extern CFStringRef kGSScreenDimensionsCapability;
+	extern CFStringRef kGSSensitiveUICapability;
+	extern CFStringRef kGSTVOutSettingsCapability;
+	extern CFStringRef kGSTelephonyCapability;
+	extern CFStringRef kGSUnifiedIPodCapability;
+	extern CFStringRef kGSVideoCameraCapability;
+	extern CFStringRef kGSVoiceControlCapability;
+	extern CFStringRef kGSVolumeButtonCapability;
+	extern CFStringRef kGSWiFiCapability;
+	extern CFStringRef kGSYouTubeCapability;
+	extern CFStringRef kGSYouTubePluginCapability;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_2
+	extern CFStringRef kGS720pPlaybackCapability;
+	extern CFStringRef kGSCellularDataCapability;
+	extern CFStringRef kGSContainsCellularRadioCapability;
+	extern CFStringRef kGSDataPlanCapability;
+	extern CFStringRef kGSDisplayPortCapability;
+	extern CFStringRef kGSH264EncoderCapability;
+	extern CFStringRef kGSHideNonDefaultApplicationsCapability;
+	extern CFStringRef kGSWildcatCapability;
+#endif
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+	extern CFStringRef kGSCameraFlashCapability;
+	extern CFStringRef kGSCanRasterizeEfficientlyCapability;
+	extern CFStringRef kGSFrontFacingCameraCapability;
+	extern CFStringRef kGSHiDPICapability;
+	extern CFStringRef kGSIOSurfaceBackedImagesCapability;
+	extern CFStringRef kGSMultitaskingCapability;
+	extern CFStringRef kGSVeniceCapability;
+#endif
+	
+	/// Subcapabilities
+	extern CFStringRef kGSMainScreenHeight;
+	extern CFStringRef kGSMainScreenOrientation;
+	extern CFStringRef kGSMainScreenScale;
+	extern CFStringRef kGSMainScreenWidth;	
+	
+	extern CFStringRef kGSEnforceGoogleMail;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_2
+	extern CFStringRef kGSEnforceCameraShutterClick;
+#endif
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSColor.h
+++ b/Private Headers/GraphicsServices/GSColor.h
@@ -1,0 +1,119 @@
+/*
+
+GSColor.h ... Graphics Services Color.
+ 
+Copyright (c) 2009, KennyTM~
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the KennyTM~ nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+#ifndef GSCOLOR_H
+#define GSCOLOR_H
+
+#include <CoreGraphics/CoreGraphics.h>
+
+/*!
+ @file GSColor.h
+ @brief Mid-level wrapper of color stuff.
+ @author Kenny TM~
+ @date 2009 Aug 5
+ 
+ GSColor is a "mid-level" wrapper of some CGColor operations. It includes functions that
+  - Obtain the RGBA components of a color,
+  - Caching common colors, and
+  - Blending two colors together.
+ 
+ */
+
+#if __cplusplus
+extern "C" {
+#endif
+
+	// Returns the gAdditionalSystemColorTable.
+	// void _GSColorRegisterAdditionalSystemColors(?);
+	
+	/// Set both stroke and fill color of the context to the specified color.
+	void GSColorSetColor(CGContextRef context, CGColorRef color);
+	
+	/// Get the RGBA components (in [0, 1]) of the color.
+	void GSColorGetRGBAComponents(CGColorRef color, CGFloat* r, CGFloat* g, CGFloat* b, CGFloat* a);
+	
+	CGFloat GSColorGetAlphaComponent(CGColorRef color);	///< Get the alpha component.
+	CGFloat GSColorGetBlueComponent(CGColorRef color);	///< Get the blue component.
+	CGFloat GSColorGetGreenComponent(CGColorRef color);	///< Get the green component.
+	CGFloat GSColorGetRedComponent(CGColorRef color);	///< Get the red component.
+	
+	typedef enum GSSystemColor {
+		kGSBlackColor,
+		kGSWhiteColor,
+		kGSGrayColor,	// 50%
+		kGSLightGrayColor,	// 70% 
+		kGSDarkGrayColor,	// 30%
+		kGSRedColor,
+		kGSGreenColor,
+		kGSBlueColor,
+		kGSCyanColor,
+		kGSMagentaColor,
+		kGSYellowColor,
+		kGSOrangeColor,	// #FF8000
+		kGSPurpleColor,	// #800080
+		kGSBrownColor,	// #996633
+		kGSClearColor
+	} GSSystemColor;
+	
+	/// Get a "system color". The color will be cached by the system.
+	CGColorRef GSColorForSystemColor(GSSystemColor colorType);
+	
+	CGColorRef GSColorGetShadowColor();	///< Get the shadow color, i.e. black.
+	CGColorRef GSColorGetHighlightColor();	///< Get the highlight color, i.e. white.
+	
+	/// Set the fill and stroke color of the context to the specified system color.
+	void GSColorSetSystemColor(CGContextRef context, GSSystemColor colorType);
+	
+	/// Create a CGColor. Additionally, if the colorSpace is Device Gray or Device RGB, the color will be cached.
+	CGColorRef GSColorCreate(CGColorSpaceRef colorSpace, CGFloat components[]);
+	
+	/// Create a grayscale cached CGColor.
+	CGColorRef GSColorCreateWithDeviceWhite(CGFloat white, CGFloat alpha);
+	
+	/// Create an RGBA cached CGColor.
+	CGColorRef GSColorCreateColorWithDeviceRGBA(CGFloat r, CGFloat g, CGFloat b, CGFloat a);
+	
+	/// Create a new color by blending two colors together.
+	/// The resulting color = first * (1 - fraction) + second * fraction.
+	CGColorRef GSColorCreateBlendedColorWithFraction(CGColorRef first, CGColorRef second, CGFloat fraction);
+	
+	/// Create a shadowed color. Equivalent to GSColorCreateBlendedColorWithFraction(color, GSColorGetShadowColor(), level).
+	CGColorRef GSColorCreateShadowWithLevel(CGColorRef color, CGFloat level);
+	
+	/// Create a highlighted color. Equivalent to GSColorCreateBlendedColorWithFraction(color, GSColorGetHighlightColor(), level).
+	CGColorRef GSColorCreateHighlightWithLevel(CGColorRef color, CGFloat level);
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSEvent.h
+++ b/Private Headers/GraphicsServices/GSEvent.h
@@ -1,0 +1,472 @@
+/*
+
+GSEvent.h ... Graphics Service Events.
+ 
+Copyright (c) 2009, KennyTM~
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the KennyTM~ nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+#ifndef GSEVENT_H
+#define GSEVENT_H
+
+#include "GSWindow.h"
+#include <mach/message.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <Availability.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+    
+	typedef struct __GSEvent* GSEventRef;
+	
+	typedef struct GSPathInfo {
+		unsigned char pathIndex;		// 0x0 = 0x5C
+		unsigned char pathIdentity;		// 0x1 = 0x5D
+		unsigned char pathProximity;	// 0x2 = 0x5E
+		CGFloat pathPressure;				// 0x4 = 0x60
+		CGFloat pathMajorRadius;		// 0x8 = 0x64
+		CGPoint pathLocation;			// 0xC = 0x68
+		GSWindowRef pathWindow;			// 0x14 = 0x70
+	} GSPathInfo;	// sizeof = 0x18.
+	
+	typedef enum __GSHandInfoType {
+		kGSHandInfoTypeTouchDown = 0,
+		kGSHandInfoTypeTouchDragged = 1,
+		kGSHandInfoTypeTouchMoved = 4,
+		kGSHandInfoTypeTouchUp = 5,
+		kGSHandInfoTypeCancel = 8
+	} GSHandInfoType;
+	
+	// A.k.a. XXStruct_$jUSvD
+	typedef struct GSHandInfo {
+		GSHandInfoType type;	// 0x0 == 0x3C
+		short deltaX, deltaY;	// 2, 4 = 0x40, 0x42
+		float _0x44;
+		float _0x48;
+		float width;			// 0x10 == 0x4C
+		float _0x50;
+		float height;			// 0x18 == 0x54
+		float _0x58;
+		unsigned char _0x5C;
+		unsigned char pathInfosCount;	// 0x22 == 0x5D
+		GSPathInfo pathInfos[0];		// 0x60
+	} GSHandInfo;	// sizeof = 0x24.
+	
+	typedef struct __GSScrollWheelInfo {
+		int deltaY;
+		int deltaX;
+	} GSScrollWheelInfo;
+	
+	typedef struct __GSAccelerometerInfo {
+		CGFloat axisX, axisY, axisZ;
+	} GSAccelerometerInfo;
+	
+	typedef struct __GSDeviceOrientationInfo {
+		int orientation;
+	} GSDeviceOrientationInfo;
+	
+	typedef struct __GSKeyInfo {
+		UniChar keyCode, characterIgnoringModifier, charCode;	// 0x3C, 0x3E, 0x40
+		unsigned short characterSet;	// 0x42
+		Boolean isKeyRepeating;	// 0x44
+	} GSKeyInfo;
+	
+	typedef struct __GSHardwareKeyInfo {
+		UniChar keyCode;	// 3c
+		UniChar characterIgnoringModifier;	// 3e
+		UniChar charCode;	// 40
+		unsigned short characterSet;	// 42
+		uint16_t characters_length;	// 44
+		UniChar characters[32];		// 46 .. 84
+		uint16_t unmodified_characters_length;	// 86
+		UniChar unmodified_characters[32];		// 88 .. C6
+		int unknown0 : 1;
+		int isKeyVariant : 1;
+		int unknown2 : 14;
+		int unknown10 : 16;
+	} GSHardwareKeyInfo;
+	
+	typedef struct __GSAccessoryKeyStateInfo {
+		unsigned short a;
+		int b;
+	} GSAccessoryKeyStateInfo;
+	
+	typedef struct __GSAppPreferencesChangedInfo {
+		size_t length;
+		char appName[0];
+	} GSAppPreferencesChangedInfo;
+	
+	typedef struct __GSResetIdleDurationInfo {
+		int a, b;
+	} GSResetIdleDurationInfo;
+	
+	typedef struct __GSEventProcessScriptInfo {
+		int type;
+		size_t length;
+		char data[0];
+	} GSEventProcessScriptInfo;
+	
+	typedef enum __GSEventType {
+		kGSEventLeftMouseDown    = 1,
+		kGSEventLeftMouseUp      = 2,
+		kGSEventMouseMoved       = 5,
+		kGSEventLeftMouseDragged = 6,
+		
+		kGSEventKeyDown = 10,
+		kGSEventKeyUp = 11,
+		kGSEventModifiersChanged = 12,
+		kGSEventSimulatorKeyDown = 13,
+		kGSEventHardwareKeyDown = 14,	// Maybe?
+		kGSEventScrollWheel = 22,
+		kGSEventAccelerate = 23,
+		kGSEventProximityStateChanged = 24,
+		kGSEventDeviceOrientationChanged = 50,
+		kGSAppPreferencesChanged = 60,
+		kGSEventUserDefaultsDidChange = 60,	// backward compatibility.
+		
+		kGSEventResetIdleTimer = 100,
+		kGSEventResetIdleDuration = 101,
+		kGSEventProcessScript = 200,
+		kGSEventDumpUIHierarchy = 500,
+		kGSEventDumpScreenContents = 501,
+		
+		kGSEventMenuButtonDown = 1000,
+		kGSEventMenuButtonUp = 1001,
+		kGSEventVolumeChanged = 1006,
+		kGSEventVolumeUpButtonDown = 1006,
+		kGSEventVolumeUpButtonUp = 1007,
+		kGSEventVolumeDownButtonDown = 1008,
+		kGSEventVolumeDownButtonUp = 1009,
+		kGSEventLockButtonDown = 1010,
+		kGSEventLockButtonUp = 1011,
+		kGSEventRingerOff = 1012,
+		kGSEventRingerOn = 1013,
+		kGSEventRingerChanged = 1013,	// backward compatibility.
+		kGSEventLockDevice = 1014,
+		kGSEventStatusBarMouseDown = 1015,
+		kGSEventStatusBarMouseDragged = 1016,
+		kGSEventStatusBarMouseUp = 1017,
+		kGSEventHeadsetButtonDown = 1018,
+		kGSEventHeadsetButtonUp = 1019,
+		kGSEventMotionBegin = 1020,
+		kGSEventHeadsetAvailabilityChanged = 1021,
+		kGSEventMediaKeyDown = 1022,	// ≥3.2
+		kGSEventMediaKeyUp = 1023,	// ≥3.2
+		
+		kGSEventVibrate = 1100,
+		kGSEventSetBacklightFactor = 1102,
+		kGSEventSetBacklightLevel = 1103,
+		
+		kGSEventApplicationLaunch = 2000,
+		kGSEventAnotherApplicationFinishedLaunching = 2001,
+		kGSEventSetAppThreadPriority = 2002,
+		kGSEventApplicationResume = 2003,		
+		kGSEventApplicationDidEndResumeAnimation = 2004,
+		kGSEventApplicationBeginSuspendAnimation = 2005,
+		kGSEventApplicationHandleTestURL = 2006,
+		kGSEventApplicationSuspendEventsOnly = 2007,
+		kGSEventApplicationSuspend = 2008,
+		kGSEventApplicationExit = 2009,
+		kGSEventQuitTopApplication = 2010,
+		kGSEventApplicationUpdateSuspendedSettings = 2011,
+		
+		kGSEventHand = 3001,
+		
+		kGSEventAccessoryAvailabilityChanged = 4000,
+		kGSEventAccessoryKeyStateChanged = 4001,
+		kGSEventAccessory = 4002,
+		
+		kGSEventOutOfLineDataRequest = 5000,
+		kGSEventOutOfLineDataResponse = 5001,
+		
+		kGSEventUrgentMemoryWarning = 6000,
+		
+		kGSEventShouldRouteToFrontMost = 1<<17
+	} GSEventType;
+	
+	typedef enum __GSEventSubType {
+		kGSEventSubTypeUnknown,
+	} GSEventSubType;
+	
+	typedef enum GSEventFlags {
+		kGSEventFlagMaskShift     = 1 << 17,
+		kGSEventFlagMaskControl   = 1 << 18,
+		kGSEventFlagMaskAlternate = 1 << 19,
+		kGSEventFlagMaskCommand   = 1 << 20
+	} GSEventFlags;	
+	
+	typedef struct GSEventRecord {
+		GSEventType type; // 0x8
+		GSEventSubType subtype;	// 0xC
+		CGPoint location; 	// 0x10
+		CGPoint windowLocation;	// 0x18
+		int windowContextId;	// 0x20
+		uint64_t timestamp;	// 0x24, from mach_absolute_time
+		GSWindowRef window;	// 0x2C
+		GSEventFlags flags;	// 0x30
+		unsigned senderPID;	// 0x34
+		CFIndex infoSize; // 0x38
+	} GSEventRecord;
+	
+#pragma mark -
+#pragma mark General info
+	
+	CFTypeID GSEventGetTypeID();
+	
+	GSEventRef GSEventCopy(GSEventRef event);
+	GSEventRef GSEventCreateWithEventRecord(const GSEventRecord* record);
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_0 && __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	GSEventRef GSEventCreateWithTypeAndLocation(GSEventType type, CGPoint location);
+#endif
+	GSEventRef GSEventCreateWithPlist(CFDictionaryRef dictionary) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_2_2);
+	
+	const GSEventRecord* GSEventRecordGetRecordDataWithPlist(CFDictionaryRef plist) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_2_2);
+	void GSEventRecordGetRecordWithPlist(GSEventRef event_to_fill, CFDictionaryRef plist) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_2_2);
+	CFDictionaryRef GSEventCreatePlistRepresentation(GSEventRef event) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_2_2);
+	
+	Boolean GSEventShouldRouteToFrontMost(GSEventRef event);
+	void GSEventRemoveShouldRouteToFrontMost(GSEventRef event);
+
+	GSEventType GSEventGetType(GSEventRef event);
+	GSEventSubType GSEventGetSubType(GSEventRef event);
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_0 && __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	int GSEventGetWindowContextId(GSEventRef event);
+#endif
+	CGPoint GSEventGetLocationInWindow(GSEventRef event);
+	CGPoint GSEventGetOuterMostPathPosition(GSEventRef event);
+	CGPoint GSEventGetInnerMostPathPosition(GSEventRef event);
+	CFAbsoluteTime GSEventGetTimestamp(GSEventRef event);
+	GSWindowRef GSEventGetWindow(GSEventRef event);
+	unsigned GSEventGetSenderPID(GSEventRef event) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_3_0);
+
+	const GSEventRecord* _GSEventGetGSEventRecord(GSEventRef event);
+	
+	void GSEventSetLocationInWindow(GSEventRef event, CGPoint location);
+	void GSEventSetType(GSEventRef event, GSEventType type);
+	
+	// GSHiccupsEnabled
+#pragma mark -
+#pragma mark Event queue processing
+	
+	Boolean GSEventQueueContainsMouseEvent();
+	mach_port_t GSGetPurpleApplicationPort() __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_3_0);
+	
+	Boolean GSGetTimeEventHandling();
+	void GSSetTimeEventHandling(Boolean enable);
+	void GSSaveEventHandlingTimes();
+	
+	CFAbsoluteTime _GSEventConvertFromMachTime(uint64_t machTime);
+	uint64_t GSCurrentEventTimestamp();
+	
+	mach_port_name_t GSRegisterPurpleNamedPort(const char* service_name);
+	mach_port_name_t GSCopyPurpleNamedPort(const char* service_name);
+	mach_port_name_t GSGetPurpleSystemEventPort() __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_3_0);
+	
+	void GSEventPopRunLoopMode(CFStringRef mode);	///< Stop the event run loop, and remove "mode" from the run loop mode stack if it is at the top.
+	void GSEventPushRunLoopMode(CFStringRef mode);	///< Stop the event run loop and push "mode" to the top of run loop mode stack.
+	
+	void GSEventStopModal();
+	void GSEventRunModal(Boolean disallow_restart);
+	void GSEventRun();
+	
+	void GSEventInitialize(Boolean registerPurple);
+	
+#pragma mark -
+#pragma mark Sending events
+	void GSSendEvent(const GSEventRecord* record, mach_port_t port);
+	void GSSendSimpleEvent(GSEventType type, mach_port_t port) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_3_0);	///< This calls GSSendEvent with an empty record.
+	void GSSendSystemEvent(const GSEventRecord* record);	///< Send event to the PurpleSystemEventPort.	
+	
+#pragma mark -
+#pragma mark Callback functions
+	
+	/// Only 1 function can be registered.
+	
+	/// Register a callback function that will be called when PurpleEventCallback() is called.
+	void GSEventRegisterEventCallBack(void(*callback)(GSEventRef event));
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	void GSEventRegisterFindWindowCallBack(int(*callback)(CGPoint position));
+	void GSEventRegisterTransformToWindowCoordsCallBack(void*) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_3_0);
+#endif
+		
+#pragma mark -
+#pragma mark Touch events
+	GSHandInfo GSEventGetHandInfo(GSEventRef event);
+	GSPathInfo GSEventGetPathInfoAtIndex(GSEventRef event, CFIndex index);
+	void GSEventSetPathInfoAtIndex(GSEventRef event, GSPathInfo pathInfo, CFIndex index);
+	
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_1
+	void GSEventSetHandInfoScale(GSEventRef event, CGFloat denominator);
+#endif
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_0 && __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	void GSEventChangeHandInfoToCancel(GSEventRef event);
+#endif
+	
+	void GSEventDisableHandEventCoalescing(Boolean disableHandCoalescing);
+	
+	Boolean GSEventIsHandEvent(GSEventRef event);
+	Boolean GSEventIsChordingHandEvent(GSEventRef event);
+	
+	// Always returns 1.
+	int GSEventGetClickCount(GSEventRef event);
+	
+#pragma mark -
+#pragma mark Scroll wheel and touch events
+	CGFloat GSEventGetDeltaX(GSEventRef event);
+	CGFloat GSEventGetDeltaY(GSEventRef event);
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	void GSEventSetDeltaX(GSEventRef event, CGFloat deltaX);
+	void GSEventSetDeltaY(GSEventRef event, CGFloat deltaY);
+#endif
+	
+#pragma mark -
+#pragma mark Keyboard events
+	unsigned short GSEventGetCharacterSet(GSEventRef event);
+	GSEventFlags GSEventGetModifierFlags(GSEventRef event);
+	Boolean GSEventIsKeyRepeating(GSEventRef event);
+	UniChar GSEventGetKeyCode(GSEventRef event);
+	
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	GSEventRef _GSCreateSyntheticKeyEvent(UniChar keycode, Boolean isKeyUp, Boolean isKeyRepeating);
+#endif
+	Boolean GSEventIsKeyCharacterEventType(GSEventRef event, UniChar expected_keycode);
+	Boolean GSEventIsTabKeyEvent(GSEventRef event);
+	
+	CFStringRef GSEventCopyCharactersIgnoringModifiers(GSEventRef event);
+	CFStringRef GSEventCopyCharacters(GSEventRef event);
+	
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	void _GSPostSyntheticKeyEvent(CFStringRef keys, Boolean isKeyUp, Boolean isKeyRepeating);
+#endif
+	
+#pragma mark -
+#pragma mark Accelerometer events
+	CGFloat GSEventAccelerometerAxisX(GSEventRef event);
+	CGFloat GSEventAccelerometerAxisY(GSEventRef event);
+	CGFloat GSEventAccelerometerAxisZ(GSEventRef event);
+	
+#pragma mark -
+#pragma mark Out-of-line data (deprecated)
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	void GSEventRequestOutOfLineData(mach_port_t port, void* unknown);
+	mach_msg_return_t GSEventSendOutOfLineData(mach_port_t port, ...);	
+#endif
+	
+#pragma mark -
+#pragma mark Hardware manipulation events
+	int GSEventDeviceOrientation(GSEventRef event);
+	void GSEventRotateSimulator(int x);	// -1 = home button on the left, 0 = portrait, 1 = home button on the right.
+	
+	void GSEventRestoreSensitivity();
+	void GSEventSetSensitivity(int sensitivity);	// or float?
+	
+	void GSEventLockDevice();	// 1014.
+
+	void GSEventResetIdleTimer();
+	void GSEventResetIdleDuration(int a, int b);
+	
+	void GSEventSetBacklightLevel(float level);
+	void GSEventSetBacklightFactor(int factor);
+	
+#pragma mark -
+#pragma mark Application events
+	Boolean GSEventIsForceQuitEvent(GSEventRef event);
+	void GSEventQuitTopApplication();	// 2010.
+	
+	void GSSendAppPreferencesChanged(CFStringRef service_name, CFStringRef app_id);
+	
+	void GSSendApplicationSuspendedSettingsUpdatedEvent(int x, int y, CFStringRef suspendedDefaultPNG, CFStringRef roleID);
+	void GSSendApplicationSuspendedEvent(int x, int y, CFStringRef suspendedDefaultPNG, CFStringRef roleID);
+	void GSEventFinishedActivating(Boolean b) __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_3_0);
+	
+	void GSEventSendApplicationOpenURL(CFURLRef url, mach_port_t port);
+	
+#pragma mark -
+#pragma mark Accessory key state events
+	GSAccessoryKeyStateInfo GSEventGetAccessoryKeyStateInfo(GSEventRef event);
+	GSEventRef GSEventCreateAccessoryKeyStateEvent(GSEventRef event, GSEventFlags flags);
+	void GSEventAccessoryKeyStateChanged(unsigned short a, int b, GSEventFlags flags);
+	void GSEventAccessoryAvailabilityChanged(unsigned short a, int b);
+		
+#pragma mark -
+#pragma mark Audio events
+	SInt32 _GSEventGetSoundActionID(CFStringRef path);
+	void _GSEventPlayAlertOrSystemSoundAtPath(CFStringRef path, Boolean loop, Boolean alert);
+	
+	SInt32 GSEventPrimeSoundAtPath(CFStringRef path);
+	void GSEventStopSoundAtPath(CFStringRef path, Boolean unknown);
+	void GSEventPlayAlertSoundAtPath(CFStringRef path);// Equivalent to _GSEventPlayAlertOrSystemSoundAtPath(path, 0, 1)
+	void GSEventLoopSoundAtPath(CFStringRef path);// Equivalent to _GSEventPlayAlertOrSystemSoundAtPath(path, 1, 0)
+	void GSEventPlaySoundAtPath(CFStringRef path);// Equivalent to _GSEventPlayAlertOrSystemSoundAtPath(path, 0, 0)
+	
+	void GSEventVibrateForDuration(float secs);
+	void GSEventStopVibrator();	///< Equivalent to GSEventVibrateForDuration(0)
+
+#pragma mark -
+#pragma mark Hardware keyboard events
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_2
+	extern const char* kGSEventHardwareKeyboardAvailabilityChangedNotification;	// "GSEventHardwareKeyboardAttached"
+	Boolean GSEventIsHardwareKeyboardAttached(void);
+	void GSEventSetHardwareKeyboardAttached(Boolean attached);
+	
+	// "type" must be 10 or 14.
+	GSEventRef GSEventCreateKeyEvent(GSEventType type,
+									 CGPoint windowLocation,
+									 CFStringRef characters,
+									 CFStringRef unmodifiedCharacters,
+									 GSEventFlags modifiers,
+									 uint16_t usagePage,
+									 unsigned options7, unsigned options8);
+	void GSSendKeyEvent(GSEventType type,
+						CGPoint windowLocation,
+						CFStringRef characters,
+						CFStringRef unmodifiedCharacters,
+						GSEventFlags modifiers,
+						uint16_t usagePage,
+						unsigned short options7,
+						unsigned short options8);
+	
+	uint16_t GSEventGetUsagePage(GSEventRef event);
+	void GSEventSetCharCode(GSEventRef event, UniChar charCode);
+	void GSEventSetCharacters(GSEventRef event, CFStringRef characters);
+	void GSEventSetKeyCode(GSEventRef event, uint16_t keyCode);
+	void GSEventSetUnmodifiedCharacters(GSEventRef event, CFStringRef characters);
+	
+	Boolean GSEventIsHardwareKeyboardEvent(GSEventRef event);
+	Boolean GSEventIsKeyVariant(GSEventRef event);
+	
+#endif
+		
+//	    void _UIApplicationHandleEvent(GSEventRef eventRef);
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSFont.h
+++ b/Private Headers/GraphicsServices/GSFont.h
@@ -1,0 +1,158 @@
+/*
+
+GSFont.h ... Graphics Service Font
+ 
+Copyright (c) 2009, KennyTM~
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the KennyTM~ nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+#ifndef GSFONT_H
+#define GSFONT_H
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <Availability2.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+	
+	/*!
+	 @file GSFont.h
+	 @brief Mid-level wrapper of font stuff.
+	 @author Kenny TM~
+	 @date 2009 Aug 5
+	 
+	 GSFont is a "mid-level" wrapper of many CGFont operations. It includes functions that
+	  - Caching common fonts, and
+	  - Creating common fonts by a font family, traits and size.
+	 */
+	
+	
+	typedef struct __GSFont* GSFontRef;
+	
+	typedef enum __GSFontTraitMask {
+		// Why not kGS...? Ask Apple. http://www.opensource.apple.com/source/WebCore/WebCore-351.9/platform/graphics/mac/FontCacheMac.mm
+		GSItalicFontMask = 1,
+		GSBoldFontMask = 2,
+		// Backward compatibility with WinterBoard.
+		kGSFontTraitNone = 0,
+		kGSFontTraitBold = 1,
+		kGSFontTraitItalic = 2,
+		kGSFontTraitBoldItalic = 3
+	} GSFontTraitMask;
+	
+	// Backward compatibility with WinterBoard.
+	typedef GSFontTraitMask GSFontTrait;
+	 
+	/*
+	 struct __GSFont {
+		 __CFRuntimeBase _base;	// 0
+		 CGFontRef _cgFont;		// 8
+		 CGFloat _size;	// c
+		 struct GSFontTraits _traits;	// 10
+		 struct GSFontTraits _xorTraits;	// 14
+		 CGFloat _ascent;	// 18
+		 CGFloat _descent;	// 1c
+		 CGFloat _lineSpacing;	// 20
+		 CGFloat _lineGap;	// 24
+		CGFloat _maximumAdvanceWidth // 28 (since 3.2)
+	 }
+	 */
+	
+	CFHashCode GSFontHash(GSFontRef font);	///< Compute the font's hash value.
+	Boolean GSFontEqual(GSFontRef a, GSFontRef b);	///< Determine if two fonts are equal.
+	CFTypeID GSFontGetTypeID();	///< Get the CoreFoundation type identifier of GSFont.
+	
+	/*!
+	 @brief Set to use legacy font metrics or not.
+	 
+	 The setting will apply when you create a GSFont. The difference between using legacy metrics or not is that, with
+	 the modern metrics, most floating point operations are single precision, and float-to-int operations are rounded up
+	 (ceiling), while for legacy metrics there are more double precision operations and floating points are rounded to the
+	 nearest integers (floor(0.5+x)). There may be some other differences in the algorithm.
+	 */
+	void GSFontSetUseLegacyFontMetrics(Boolean useLegacyFontMetrics);
+	Boolean GSFontGetUseLegacyFontMetrics();	///< Get whether legacy font metrics is used.
+	
+	CGFontRef GSFontGetCGFont(GSFontRef font);	///< Get CGFont from a GSFont.
+	Boolean GSFontIsBold(GSFontRef font);	///< Check whether a font is bold.
+	GSFontTraitMask GSFontGetTraits(GSFontRef font);	///< Get the traits mask of the font.
+	GSFontTraitMask GSFontGetSynthesizedTraits(GSFontRef font);	///< Get the synthesized traits mask of the font.
+	CGFloat GSFontGetSize(GSFontRef font);	///< Get the font's point size
+	CGFloat GSFontGetAscent(GSFontRef font);	///< Get the font's ascent.
+	CGFloat GSFontGetDescent(GSFontRef font);	///< Get the font's descent.
+	CGFloat GSFontGetLineSpacing(GSFontRef font);	///< Get the font's line spacing.
+	CGFloat GSFontGetLineGap(GSFontRef font);	///< Get the font's line gap.
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_2
+	CGFloat GSFontGetMaximumAdvanceWidth(GSFontRef font);	///< Get the font's maximum advance width.
+#endif
+	
+	typedef enum CGFontRenderingMode {
+		kCGFontRenderingModeAntialiased = 3
+	} CGFontRenderingMode;
+	
+	/// Compute the transformed advances (occupied size?) of glyphs in the font.
+	Boolean GSFontGetGlyphTransformedAdvances(GSFontRef font, const CGAffineTransform transforms[], CGFontRenderingMode mode, const CGGlyph glyph[], unsigned count, CGSize transformedAdvances[]);
+	
+	/// Find the glyphs of the corresponding Unicode characters.
+	void GSFontGetGlyphsForUnichars(GSFontRef font, const UniChar unichars[], CGGlyph glyphs[], size_t count);
+	size_t GSFontGetNumberOfGlyphs(GSFontRef font);	///< Get the number of glyphs in the font.
+	
+	int GSFontGetUnitsPerEm(GSFontRef font);
+	CGFloat GSFontGetCapHeight(GSFontRef font);
+	CGFloat GSFontGetXHeight(GSFontRef font);
+	
+	GSFontTraitMask GSFontGetTraitsForName(const char* fontName);
+	Boolean GSFontIsFixedPitch(GSFontRef font);
+	
+	const char* GSFontGetFamilyName(GSFontRef font);
+	const char* GSFontGetFullName(GSFontRef font);
+	CFArrayRef GSFontCopyFontNamesForFamilyName(const char* familyName);	// an array of CFString, not const char*
+	CFArrayRef GSFontCopyFamilyNames();
+	
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	void GSFontPurgeFontCache();
+#endif
+	void GSFontInitialize();
+	
+	/// Use the specified font in the context.
+	void GSFontSetFont(CGContextRef context, GSFontRef font);
+	
+	/// Add a CGFont for search.
+	Boolean GSFontAddCGFont(CGFontRef cgFont);
+	/// Add a font from a file to search.
+	Boolean GSFontAddFromFile(const char* filename);
+	
+	GSFontRef GSFontCreateWithName(const char* fontName, GSFontTraitMask traits, CGFloat fontSize);
+	const char* GSFontGetPostScriptName(GSFontRef font);
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSGeometry.h
+++ b/Private Headers/GraphicsServices/GSGeometry.h
@@ -1,0 +1,56 @@
+/*
+ 
+GSGeometry.h ... Geometry-related APIs.
+
+Copyright (c) 2009  KennyTM~ <kennytm@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the KennyTM~ nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef GSGEOMETRY_H
+#define GSGEOMETRY_H
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+	CGAffineTransform GSGeometryGetTransformFromRectToRect(CGRect from, CGRect to);
+
+	/// Create a string representing the affine transform, in the form "[%f %f %f %f %f %f]"
+	CFStringRef CFStringCreateWithCGAffineTransform(CGAffineTransform tx);
+	
+	CFStringRef CFStringCreateWithCGSize(CGSize size);
+	CFStringRef CFStringCreateWithCGPoint(CGPoint pt);
+	CFStringRef CFStringCreateWithCGRect(CGRect rect);
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSHeartbeat.h
+++ b/Private Headers/GraphicsServices/GSHeartbeat.h
@@ -1,0 +1,88 @@
+/*
+ 
+FILE_NAME ... FILE_DESCRIPTION
+
+Copyright (c) 2009  KennyTM~ <kennytm@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the KennyTM~ nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef GSHEARTBEAT_H
+#define GSHEARTBEAT_H
+
+#include <CoreGraphics/CoreGraphics.h>
+
+#if __cplusplus
+extern "C" {
+#endif	
+	
+	/*!
+	 @file GSHeartbeat.h
+	 @brief Calls function when display updates
+	 @author Kenny TM~
+	 @date 2009 Sept 24
+	 
+	 GSHeartbeat is an API that allows you to register a callback function when the display is updated. It has the same
+	 purpose as CADisplayLink, but have different origin.
+	 
+	 */	
+	
+	typedef struct __GSHeartbeat* GSHeartbeatRef;
+	typedef double GSHeartbeatTime;
+	typedef void (*GSHeartbeatCallback)(void* context, GSHeartbeatTime time);
+	
+	/*
+	 struct __GSHeartbeat {
+		 arg0 // 8
+		 arg3 // c
+		 Boolean isPaused;	// 10
+		 CFRunLoopRef runloop // 14
+		 CFStringRef mode; // 18
+		 void* framebuffer; // 1c
+		 CFRunLoopSourceRef source;	// 20
+	 }
+	 */
+	
+
+	GSHeartbeatTime GSHeartbeatGetCurrentTime();
+	
+	CFTypeID GSHeartbeatGetTypeID();
+	
+	GSHeartbeatRef GSHeartbeatCreate(GSHeartbeatCallback callback, CFStringRef runloopMode, Boolean useTVOut, void* context);
+	
+	Boolean GSHeartbeatIsPaused(GSHeartbeatRef heartbeat);
+	void GSHeartbeatPause(GSHeartbeatRef heartbeat, Boolean pause_on);
+	
+	void GSHeartbeatSetRunLoopMode(GSHeartbeatRef heartbeat, CFStringRef mode);
+	void GSHeartbeatTickle(GSHeartbeatRef heartbeat, CFRunLoopRef runloop);
+	
+	void GSHeartbeatInvalidate(GSHeartbeatRef heartbeat);
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSHiccup.h
+++ b/Private Headers/GraphicsServices/GSHiccup.h
@@ -1,0 +1,55 @@
+/*
+ 
+GSHiccups.h ... Hiccups.
+
+Copyright (c) 2009  KennyTM~ <kennytm@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the KennyTM~ nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef GSHICCUPS_H
+#define GSHICCUPS_H
+
+#if __cplusplus
+extern "C" {
+#endif
+
+	void GSDisallowSpinTrace();
+	void GSAllowSpinTrace();
+	void GSStopWatchingForHiccups();
+	void GSStartWatchingForHiccups();
+	
+	void GSSampleSelfWithThreads(int r0, int* r1, Boolean threads);
+	void GSSampleSelf(int r0, int* r1);	///< Calls *r1 = 0; GSSampleSelfWithThreads(r0, r1, true);
+	
+	// which is a capability.
+	extern CFStringRef kGSHiccoughInterval;
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSKeyboard.h
+++ b/Private Headers/GraphicsServices/GSKeyboard.h
@@ -1,0 +1,113 @@
+/*
+ 
+GSKeyboard.h ... Hardware keyboard.
+
+Copyright (c) 2010  KennyTM~ <kennytm@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the KennyTM~ nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef GSKEYBOARD_H
+#define GSKEYBOARD_H
+
+#include <Availability2.h>
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_2
+
+#if __cplusplus
+extern "C" {
+#endif
+	
+#include <CoreFoundation/CoreFoundation.h>
+#include "GSEvent.h"
+	
+	enum {
+		kUCKeyActionDown = 0,
+		kUCKeyActionUp = 1,
+		kUCKeyActionAutoKey = 2,
+		kUCKeyActionDisplay = 3
+	};
+		
+	typedef struct __GSKeyboard
+#if 0
+	{
+		CFRuntimeBase base;	// 0, 4
+		int fildes;
+		void* ptr;
+		size_t length;
+		struct uchrKeyboardLayout* keyLayoutPtr;
+		UInt32 keyboardType;
+		UInt32 deadKeyState;
+		int modifierState;	// 2 = shift, 4 = ctrl, 8 = alt, 16 = cmd
+		CFStringRef layoutName;
+		pthread_mutex_t mutex;
+	}
+#endif
+	* GSKeyboardRef;
+	
+	// The keyboard layout list is stored in /System/Library/KeyboardLayouts/USBKeyboardLayouts.bundle/USBKeyboardLayouts.plist
+	CFDictionaryRef GSKeyboardHWKeyboardLayoutsPlist(void);
+	
+	CFTypeID GSKeyboardGetTypeID(void);
+	
+	GSKeyboardRef GSKeyboardCreate(CFStringRef layoutName, UInt32 keyboardType);
+	void GSKeyboardRelease(GSKeyboardRef keyboard);
+	
+	void GSKeyboardReset(GSKeyboardRef keyboard);
+	
+	CFStringRef GSKeyboardGetLayout(GSKeyboardRef keyboard);
+	void GSKeyboardSetLayout(GSKeyboardRef keyboard, CFStringRef layoutName);
+	
+	GSEventFlags GSKeyboardGetModifierState(GSKeyboardRef keyboard);
+	
+	// ref: http://developer.apple.com/mac/library/documentation/Carbon/Reference/Unicode_Utilities_Ref/Reference/reference.html#//apple_ref/doc/uid/TP30000122-CH1g-F10792
+	OSStatus GSKeyTranslate(GSKeyboardRef keyboard,
+							UInt16 virtualKeyCode, 
+							UInt16 keyAction,
+							UInt32 modifierKeyState,
+							UInt32 keyboardType,
+							OptionBits keyTranslateOptions,
+							UInt32 *deadKeyState,
+							UniCharCount maxStringLength,
+							UniCharCount *actualStringLength,
+							UniChar unicodeString[]);		   
+
+	OSStatus GSKeyboardTranslateKey(GSKeyboardRef keyboard,
+									UInt16 virtualKeyCode,
+									UInt16 unknown,
+									OptionBits keyTranslateOptions,
+									UniCharCount maxStringLength,
+									UniCharCount *actualStringLength,
+									UniChar unicodeString[],
+									UniCharCount *actualStringLength2,
+									UniChar unicodeString2[]);
+	
+#if __cplusplus
+}
+#endif
+
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSMainScreen.h
+++ b/Private Headers/GraphicsServices/GSMainScreen.h
@@ -1,0 +1,61 @@
+/*
+ 
+GSMainScreen.h ... Manipulating the main screen
+
+Copyright (c) 2009  KennyTM~ <kennytm@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the KennyTM~ nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef GSMAINSCREEN_H
+#define GSMAINSCREEN_H
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <Availability2.h>
+
+#if __cplusplus
+extern "C" {
+#endif	
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+	CGRect GSFullScreenApplicationContentRect();
+#else
+	CGSize GSMainScreenPixelSize(void);	// default to 320 x 480.
+	CGSize GSMainScreenPointSize(void);	// default to 320 x 480.
+#endif
+	
+	void GSSetMainScreenInfo(CGSize screenSize, CGFloat screenScale, int screenOrientation);
+	CGAffineTransform GSMainScreenPositionTransform();
+	CGAffineTransform GSMainScreenWindowTransform();
+	int GSMainScreenOrientation();
+	CGFloat GSMainScreenScaleFactor();
+	CGSize GSMainScreenSize();
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSMaps.h
+++ b/Private Headers/GraphicsServices/GSMaps.h
@@ -1,0 +1,68 @@
+/*
+
+GSMaps.h ... Graphics Service Maps.
+ 
+Copyright (c) 2009, KennyTM~
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the KennyTM~ nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+#ifndef GSMAPS_H
+#define GSMAPS_H
+
+#include <Availability2.h>
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_1
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+	/// Synchronize the com.apple.GMM preferences.
+	void GSUpdateMapsVisibilityPrefs();
+	
+	/// Returns the MapKitUserShifting[Non]GreenTea setting from com.apple.GMM.
+	Boolean GSMapKitUserShifting();
+	/// Returns the MapsUserShifting[Non]GreenTea setting from com.apple.GMM.
+	Boolean GSMapsUserShifting();
+	/// Return true, or MapKitAvailableGreenTea setting from com.apple.GMM if the system has green-tea capability.
+	Boolean GSMapKitAvailable();
+	/// Returns true, or MapsVisibleGreenTea from com.apple.GMM if the system has green-tea capability.
+	/// This value will be refreshed when the carrier changes.
+	Boolean GSMapsVisible();
+	
+	extern CFStringRef kGSMapsVisibilityChangedNotification;
+
+
+#if __cplusplus
+}
+#endif
+
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSStatusBar.h
+++ b/Private Headers/GraphicsServices/GSStatusBar.h
@@ -1,0 +1,55 @@
+/*
+ 
+GSStatusBar.h ... Manipulating the status bar
+
+Copyright (c) 2009  KennyTM~ <kennytm@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, 
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the KennyTM~ nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef GSSTATUSBAR_H
+#define GSSTATUSBAR_H
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <Availability2.h>
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_3_2
+
+#if __cplusplus
+extern "C" {
+#endif	
+
+	CGFloat GSStatusBarHeight();
+	CGFloat GSDefaultStatusBarHeight();	// = 20
+	CGFloat GSSetStatusBarHeight(CGFloat newHeight);
+	
+#if __cplusplus
+}
+#endif
+
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GSWindow.h
+++ b/Private Headers/GraphicsServices/GSWindow.h
@@ -1,0 +1,54 @@
+/*
+
+GSWindow.h ... Graphics Services Window.
+ 
+Copyright (c) 2009, KennyTM~
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the KennyTM~ nor the names of its contributors may be
+   used to endorse or promote products derived from this software without
+   specific prior written permission.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+
+#ifndef GSWINDOW_H
+#define GSWINDOW_H
+
+/*!
+ @file GSWindow.h
+ @brief ???
+ @author Kenny TM~
+ @date 2009 Sep 16
+ 
+ */
+
+#if __cplusplus
+extern "C" {
+#endif
+
+	typedef void* GSWindowRef;
+	
+#if __cplusplus
+}
+#endif
+
+#endif

--- a/Private Headers/GraphicsServices/GraphicsServices.h
+++ b/Private Headers/GraphicsServices/GraphicsServices.h
@@ -1,0 +1,16 @@
+#ifndef GRAPHICS_SERVICES_H
+#define GRAPHICS_SERVICES_H
+
+#include "GSBase.h"
+#include "GSColor.h"
+#include "GSEvent.h"
+#include "GSFont.h"
+#include "GSCapability.h"
+#include "GSGeometry.h"
+#include "GSHeartbeat.h"
+#include "GSHiccup.h"
+#include "GSMainScreen.h"
+#include "GSMaps.h"
+#include "GSStatusBar.h"
+
+#endif

--- a/src/components/UIQueryScrollView.h
+++ b/src/components/UIQueryScrollView.h
@@ -9,6 +9,7 @@
 
 }
 
+-(UIQuery*)scrollToTop;
 -(UIQuery *)scrollDown:(int)offset;
 -(UIQuery *)scrollToBottom;
 

--- a/src/components/UIQueryScrollView.m
+++ b/src/components/UIQueryScrollView.m
@@ -4,6 +4,12 @@
 
 @implementation UIQueryScrollView
 
+-(UIQuery*)scrollToTop {
+    UIScrollView *scroller = (UIScrollView *)self;
+	[scroller setContentOffset:CGPointMake(0, 0) animated:YES];
+	return [UIQuery withViews:views className:className];
+}
+
 -(UIQuery *)scrollDown:(int)offset {
 	UIScrollView *scroller = (UIScrollView *)self;
 	[scroller setContentOffset:CGPointMake(0,offset) animated:NO];
@@ -12,8 +18,10 @@
 
 -(UIQuery *)scrollToBottom {
 	UIScrollView *scroller = (UIScrollView *)self;
-	CGPoint bottomOffset = CGPointMake(0, [scroller contentSize].height);
-	[scroller setContentOffset: bottomOffset animated: YES];
+    CGFloat scrollerSize = scroller.contentSize.height;
+    CGFloat offset = scrollerSize - scroller.frame.size.height;
+	CGPoint bottomOrigin = CGPointMake(0, offset);
+	[scroller setContentOffset: bottomOrigin animated: YES];
 	return [UIQuery withViews:views className:className];
 }
 

--- a/src/components/UIQueryTableView.h
+++ b/src/components/UIQueryTableView.h
@@ -6,13 +6,12 @@
 //  Copyright(c) 2009 StarterStep, Inc., Some rights reserved.
 //
 
-#import "UIQuery.h"
+#import "UIQueryScrollView.h"
 
-@interface UIQueryTableView : UIQuery {
+@interface UIQueryTableView : UIQueryScrollView {
 
 }
 
--(UIQuery *)scrollToBottom;
 -(UIQuery *)scrollDown:(int)numberOfRows;
 -(NSArray *)rowIndexPathList;
 

--- a/src/components/UIQueryTableView.m
+++ b/src/components/UIQueryTableView.m
@@ -1,17 +1,8 @@
-
+    
 #import "UIQueryTableView.h"
 
 
 @implementation UIQueryTableView
-
--(UIQuery *)scrollToBottom {
-	UITableView *table = (UITableView *)self;
-	int numberOfSections = [table numberOfSections];
-	int numberOfRowsInSection = [table numberOfRowsInSection:numberOfSections-1];
-	NSIndexPath *indexPath = [NSIndexPath indexPathForRow:numberOfRowsInSection-1 inSection:numberOfSections-1];
-	[table scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];
-	return [UIQuery withViews:views className:className];
-}
 
 -(UIQuery *)scrollDown:(int)numberOfRows {
 	//NSLog(@"scrollDown %d", numberOfRows);

--- a/src/dsl/UIEvent+Synthesize.h
+++ b/src/dsl/UIEvent+Synthesize.h
@@ -14,4 +14,5 @@
 + (id) eventWithTouch: (UITouch *) touch;
 - (id)initWithTouch:(UITouch *)touch;
 - (void) updateTimestamp;
+
 @end

--- a/src/dsl/UIEvent+Synthesize.h
+++ b/src/dsl/UIEvent+Synthesize.h
@@ -11,7 +11,7 @@
 
 @interface UIEvent (UIEvent_Synthesize)
 
-+ (id) eventWithTouch: (UITouch *) touch;
++ (id) applicationEventWithTouch: (UITouch *) touch;
 - (id)initWithTouch:(UITouch *)touch;
 - (void) updateTimestamp;
 

--- a/src/dsl/UIEvent+Synthesize.h
+++ b/src/dsl/UIEvent+Synthesize.h
@@ -14,5 +14,16 @@
 + (id) applicationEventWithTouch: (UITouch *) touch;
 - (id)initWithTouch:(UITouch *)touch;
 - (void) updateTimestamp;
+@end
 
+@interface UIEvent (Compiler_warnings)
+// These are just definitions of private methods, will help prevent
+// compiler from yelling at us for every private method call
+- (void) _setTimestamp: (NSTimeInterval) interval;
+- (void) _clearTouches;
+- (void) _addTouch: (UITouch*) touch forDelayedDelivery: (BOOL) delayed;
+@end
+
+@interface UIApplication(Compiler_warnings)
+- (UIEvent*) _touchesEvent;
 @end

--- a/src/dsl/UIEvent+Synthesize.m
+++ b/src/dsl/UIEvent+Synthesize.m
@@ -7,7 +7,7 @@
 //
 #import <objc/runtime.h>
 #import "UIEvent+Synthesize.h"
-
+#import "GSEvent.h"
 //
 // GSEvent is an undeclared object. We don't need to use it ourselves but some
 // Apple APIs (UIScrollView in particular) require the x and y fields to be present.
@@ -38,14 +38,55 @@
 
 - (id)_initWithEvent:(GSEventProxy *)fp8 touches:(id)fp12;
 - (void) _setTimestamp: (NSTimeInterval) interval;
+// just to shut the compiler up
+- (void) _setGSEvent:(GSEventRef) eventRef;
+- (void) _clearTouches;
+- (void) _addTouch: (UITouch*) touch forDelayedDelivery: (BOOL) delayed;
 @end
 
 @implementation UIEvent (UIEvent_Synthesize)
 
++ (NSDictionary*) recordDictionaryForViewLocation: (CGPoint) viewLocation andWindowLocation: (CGPoint) windowLocation
+{
+    NSMutableDictionary *eventRecordDict = [NSMutableDictionary dictionaryWithCapacity:4];
+    
+    // new timestamp
+    NSNumber *timestamp = [NSNumber numberWithLong: [[NSDate date] timeIntervalSince1970]];
+    [eventRecordDict setObject:timestamp forKey:@"Time"];
+    
+    // location in view dictionary
+    NSMutableDictionary *viewLocationDict = [NSMutableDictionary dictionaryWithCapacity:2];
+    [viewLocationDict setObject:[NSNumber numberWithFloat: viewLocation.x] forKey:@"X"];
+    [viewLocationDict setObject:[NSNumber numberWithFloat:viewLocation.y ] forKey:@"Y"];
+    [eventRecordDict setObject:viewLocationDict forKey:@"Location"];
+    
+    // location in window dictionary
+    NSMutableDictionary *windowDict = [NSMutableDictionary dictionaryWithCapacity:2];
+    [windowDict setObject:[NSNumber numberWithFloat: windowLocation.x] forKey:@"X"];
+    [windowDict setObject:[NSNumber numberWithFloat:windowLocation.y ] forKey:@"Y"];
+    [eventRecordDict setObject:windowDict forKey:@"WindowLocation"];
+    
+    // event type (touch)
+    NSNumber *type = [NSNumber numberWithInt: kGSEventHand];
+    [eventRecordDict setObject: type forKey:@"Type"];
+
+    return eventRecordDict;
+}
 
 + (id) eventWithTouch: (UITouch *) touch
 {    
-    UIEvent *event = [[[UIEvent alloc] initWithTouch: touch] autorelease];
+    UIEvent *event = [[UIApplication sharedApplication] _touchesEvent];
+    
+    UIWindow *window = touch.window;
+    CGPoint windowLocation = [touch locationInView: window];
+    CGPoint viewLocation = [touch locationInView: touch.view];
+    
+    CFDictionaryRef recordDictionary = (CFDictionaryRef) [UIEvent recordDictionaryForViewLocation:viewLocation andWindowLocation: windowLocation];
+    GSEventRef eventRef = GSEventCreateWithPlist(recordDictionary);
+    
+    [event _setGSEvent: eventRef];
+    [event _addTouch: touch forDelayedDelivery: NO];
+       
     return event;
 }
 

--- a/src/dsl/UIEvent+Synthesize.m
+++ b/src/dsl/UIEvent+Synthesize.m
@@ -34,14 +34,11 @@
 @implementation GSEventProxy
 @end
 
-@interface UIEvent (Creation)
-
+@interface UIEvent (Compiler_warnings_private)
+// just to shut the compiler up, private we don't want to expose GSEventRef
+// to the rest of the project
 - (id)_initWithEvent:(GSEventProxy *)fp8 touches:(id)fp12;
-- (void) _setTimestamp: (NSTimeInterval) interval;
-// just to shut the compiler up
 - (void) _setGSEvent:(GSEventRef) eventRef;
-- (void) _clearTouches;
-- (void) _addTouch: (UITouch*) touch forDelayedDelivery: (BOOL) delayed;
 @end
 
 @implementation UIEvent (UIEvent_Synthesize)

--- a/src/dsl/UIEvent+Synthesize.m
+++ b/src/dsl/UIEvent+Synthesize.m
@@ -73,7 +73,7 @@
     return eventRecordDict;
 }
 
-+ (id) eventWithTouch: (UITouch *) touch
++ (id) applicationEventWithTouch: (UITouch *) touch
 {    
     UIEvent *event = [[UIApplication sharedApplication] _touchesEvent];
     

--- a/src/dsl/UITouch+Synthesize.h
+++ b/src/dsl/UITouch+Synthesize.h
@@ -19,5 +19,13 @@
 
 - (void)setPhase:(UITouchPhase)phase;
 - (void)setLocationInWindow:(CGPoint)location;
+@end
 
+@interface UITouch(Compiler_warnings)
+- (void) setTapCount: (int) tapCount;
+- (void) setPhase: (UITouchPhase) phase;
+- (void) setIsTap: (BOOL) isTap;
+- (void) _setLocationInWindow: (CGPoint) point resetPrevious: (BOOL) resetPrevious;
+- (void) setView: (UIView*) view;
+- (void) setWindow: (UIWindow*) window;
 @end

--- a/src/dsl/UITouchPerformer.m
+++ b/src/dsl/UITouchPerformer.m
@@ -36,7 +36,7 @@
         UITouch *touch = [UITouch touchInView: targetView];
         
         // init an empty event
-        UIEvent *event = [UIEvent eventWithTouch: touch];
+        UIEvent *event = [UIEvent applicationEventWithTouch: touch];
         // populate the event
         [event _addGestureRecognizersForView: targetView toTouch: touch];    
         [event updateTimestamp];
@@ -57,7 +57,7 @@
     UITouch *touch = [UITouch touchAtPoint: point];
     
     // init an empty event
-    UIEvent *event = [UIEvent eventWithTouch: touch];
+    UIEvent *event = [UIEvent applicationEventWithTouch: touch];
     // populate the event
     [event _addGestureRecognizersForView: touch.view toTouch: touch];    
     [event updateTimestamp];
@@ -118,7 +118,7 @@
     // create initial touch and UIEvent
     UITouch *touch = [UITouch touchAtPoint: start];
     
-    UIEvent *event = [UIEvent eventWithTouch: touch];
+    UIEvent *event = [UIEvent applicationEventWithTouch: touch];
     [event _addGestureRecognizersForView: touch.view toTouch: touch];
     
     // dispatch touch down
@@ -170,7 +170,7 @@
     
     // build event with lower left touch, add gesture recognizers for that touch
     // and then add upper right touch, along with it's gesture recognizers
-    UIEvent *event = [UIEvent eventWithTouch: lowerLeftTouch];
+    UIEvent *event = [UIEvent applicationEventWithTouch: lowerLeftTouch];
     [event _addGestureRecognizersForView: lowerLeftTouch.view toTouch: lowerLeftTouch];
 
     [event _addTouch: upperRightTouch forDelayedDelivery: NO];

--- a/src/dsl/UITouchPerformer.m
+++ b/src/dsl/UITouchPerformer.m
@@ -44,6 +44,8 @@
         // dispatch phase down event
         [[UIApplication sharedApplication] sendEvent: event];
         
+        [self wait: EVENT_DELAY];
+        
         // dispatch phase up
         [touch setPhase:UITouchPhaseEnded];
         [event updateTimestamp];
@@ -53,6 +55,7 @@
 
 - (void) tapAtPoint: (CGPoint) point
 {
+    NSLog(@"Taping at: %@", NSStringFromCGPoint(point));
     // create a touch in the center of the view
     UITouch *touch = [UITouch touchAtPoint: point];
     
@@ -64,6 +67,8 @@
     
     // dispatch phase down event
     [[UIApplication sharedApplication] sendEvent: event];
+    
+    [self wait: EVENT_DELAY];
     
     // dispatch phase up
     [touch setPhase:UITouchPhaseEnded];

--- a/xcode/UISpec/UISpec.xcodeproj/project.pbxproj
+++ b/xcode/UISpec/UISpec.xcodeproj/project.pbxproj
@@ -101,6 +101,34 @@
 		008AFCE213B568DF000A5C00 /* UIEvent+Synthesize.m in Sources */ = {isa = PBXBuildFile; fileRef = 003A2ECC13B43B6B0092AD2B /* UIEvent+Synthesize.m */; };
 		008AFCE313B568DF000A5C00 /* UITouch+Synthesize.m in Sources */ = {isa = PBXBuildFile; fileRef = 003A2ED013B43B6B0092AD2B /* UITouch+Synthesize.m */; };
 		008AFCE413B568DF000A5C00 /* UITouchPerformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 003A2ED813B43BDB0092AD2B /* UITouchPerformer.m */; };
+		0097BF6913B8286D00D79E81 /* GraphicsServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5B13B8286D00D79E81 /* GraphicsServices.h */; };
+		0097BF6A13B8286D00D79E81 /* GraphicsServices.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5B13B8286D00D79E81 /* GraphicsServices.h */; };
+		0097BF6B13B8286D00D79E81 /* GSBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5C13B8286D00D79E81 /* GSBase.h */; };
+		0097BF6C13B8286D00D79E81 /* GSBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5C13B8286D00D79E81 /* GSBase.h */; };
+		0097BF6D13B8286D00D79E81 /* GSCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5D13B8286D00D79E81 /* GSCapability.h */; };
+		0097BF6E13B8286D00D79E81 /* GSCapability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5D13B8286D00D79E81 /* GSCapability.h */; };
+		0097BF6F13B8286D00D79E81 /* GSColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5E13B8286D00D79E81 /* GSColor.h */; };
+		0097BF7013B8286D00D79E81 /* GSColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5E13B8286D00D79E81 /* GSColor.h */; };
+		0097BF7113B8286D00D79E81 /* GSEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5F13B8286D00D79E81 /* GSEvent.h */; };
+		0097BF7213B8286D00D79E81 /* GSEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF5F13B8286D00D79E81 /* GSEvent.h */; };
+		0097BF7313B8286D00D79E81 /* GSFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6013B8286D00D79E81 /* GSFont.h */; };
+		0097BF7413B8286D00D79E81 /* GSFont.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6013B8286D00D79E81 /* GSFont.h */; };
+		0097BF7513B8286D00D79E81 /* GSGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6113B8286D00D79E81 /* GSGeometry.h */; };
+		0097BF7613B8286D00D79E81 /* GSGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6113B8286D00D79E81 /* GSGeometry.h */; };
+		0097BF7713B8286D00D79E81 /* GSHeartbeat.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6213B8286D00D79E81 /* GSHeartbeat.h */; };
+		0097BF7813B8286D00D79E81 /* GSHeartbeat.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6213B8286D00D79E81 /* GSHeartbeat.h */; };
+		0097BF7913B8286D00D79E81 /* GSHiccup.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6313B8286D00D79E81 /* GSHiccup.h */; };
+		0097BF7A13B8286D00D79E81 /* GSHiccup.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6313B8286D00D79E81 /* GSHiccup.h */; };
+		0097BF7B13B8286D00D79E81 /* GSKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6413B8286D00D79E81 /* GSKeyboard.h */; };
+		0097BF7C13B8286D00D79E81 /* GSKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6413B8286D00D79E81 /* GSKeyboard.h */; };
+		0097BF7D13B8286D00D79E81 /* GSMainScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6513B8286D00D79E81 /* GSMainScreen.h */; };
+		0097BF7E13B8286D00D79E81 /* GSMainScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6513B8286D00D79E81 /* GSMainScreen.h */; };
+		0097BF7F13B8286D00D79E81 /* GSMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6613B8286D00D79E81 /* GSMaps.h */; };
+		0097BF8013B8286D00D79E81 /* GSMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6613B8286D00D79E81 /* GSMaps.h */; };
+		0097BF8113B8286D00D79E81 /* GSStatusBar.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6713B8286D00D79E81 /* GSStatusBar.h */; };
+		0097BF8213B8286D00D79E81 /* GSStatusBar.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6713B8286D00D79E81 /* GSStatusBar.h */; };
+		0097BF8313B8286D00D79E81 /* GSWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6813B8286D00D79E81 /* GSWindow.h */; };
+		0097BF8413B8286D00D79E81 /* GSWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097BF6813B8286D00D79E81 /* GSWindow.h */; };
 		2FDBB75C10EECD0200193065 /* UIQuerySearchBar.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDBB75410EECD0200193065 /* UIQuerySearchBar.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2FDBB75D10EECD0200193065 /* UIQuerySearchBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FDBB75510EECD0200193065 /* UIQuerySearchBar.m */; };
 		2FDBB75E10EECD0200193065 /* UIQuerySegmentedControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDBB75610EECD0200193065 /* UIQuerySegmentedControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -204,6 +232,20 @@
 		003A2ED713B43BDB0092AD2B /* UITouchPerformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UITouchPerformer.h; sourceTree = "<group>"; };
 		003A2ED813B43BDB0092AD2B /* UITouchPerformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UITouchPerformer.m; sourceTree = "<group>"; };
 		008AFCE913B568DF000A5C00 /* libUISpec-iphonesimulator.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libUISpec-iphonesimulator.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0097BF5B13B8286D00D79E81 /* GraphicsServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphicsServices.h; sourceTree = "<group>"; };
+		0097BF5C13B8286D00D79E81 /* GSBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSBase.h; sourceTree = "<group>"; };
+		0097BF5D13B8286D00D79E81 /* GSCapability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSCapability.h; sourceTree = "<group>"; };
+		0097BF5E13B8286D00D79E81 /* GSColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSColor.h; sourceTree = "<group>"; };
+		0097BF5F13B8286D00D79E81 /* GSEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSEvent.h; sourceTree = "<group>"; };
+		0097BF6013B8286D00D79E81 /* GSFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSFont.h; sourceTree = "<group>"; };
+		0097BF6113B8286D00D79E81 /* GSGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSGeometry.h; sourceTree = "<group>"; };
+		0097BF6213B8286D00D79E81 /* GSHeartbeat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSHeartbeat.h; sourceTree = "<group>"; };
+		0097BF6313B8286D00D79E81 /* GSHiccup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSHiccup.h; sourceTree = "<group>"; };
+		0097BF6413B8286D00D79E81 /* GSKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSKeyboard.h; sourceTree = "<group>"; };
+		0097BF6513B8286D00D79E81 /* GSMainScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSMainScreen.h; sourceTree = "<group>"; };
+		0097BF6613B8286D00D79E81 /* GSMaps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSMaps.h; sourceTree = "<group>"; };
+		0097BF6713B8286D00D79E81 /* GSStatusBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSStatusBar.h; sourceTree = "<group>"; };
+		0097BF6813B8286D00D79E81 /* GSWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSWindow.h; sourceTree = "<group>"; };
 		2FDBB75410EECD0200193065 /* UIQuerySearchBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIQuerySearchBar.h; sourceTree = "<group>"; };
 		2FDBB75510EECD0200193065 /* UIQuerySearchBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIQuerySearchBar.m; sourceTree = "<group>"; };
 		2FDBB75610EECD0200193065 /* UIQuerySegmentedControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIQuerySegmentedControl.h; sourceTree = "<group>"; };
@@ -301,11 +343,42 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0097BF5913B8286D00D79E81 /* Private Headers */ = {
+			isa = PBXGroup;
+			children = (
+				0097BF5A13B8286D00D79E81 /* GraphicsServices */,
+			);
+			name = "Private Headers";
+			path = "../../Private Headers";
+			sourceTree = "<group>";
+		};
+		0097BF5A13B8286D00D79E81 /* GraphicsServices */ = {
+			isa = PBXGroup;
+			children = (
+				0097BF5B13B8286D00D79E81 /* GraphicsServices.h */,
+				0097BF5C13B8286D00D79E81 /* GSBase.h */,
+				0097BF5D13B8286D00D79E81 /* GSCapability.h */,
+				0097BF5E13B8286D00D79E81 /* GSColor.h */,
+				0097BF5F13B8286D00D79E81 /* GSEvent.h */,
+				0097BF6013B8286D00D79E81 /* GSFont.h */,
+				0097BF6113B8286D00D79E81 /* GSGeometry.h */,
+				0097BF6213B8286D00D79E81 /* GSHeartbeat.h */,
+				0097BF6313B8286D00D79E81 /* GSHiccup.h */,
+				0097BF6413B8286D00D79E81 /* GSKeyboard.h */,
+				0097BF6513B8286D00D79E81 /* GSMainScreen.h */,
+				0097BF6613B8286D00D79E81 /* GSMaps.h */,
+				0097BF6713B8286D00D79E81 /* GSStatusBar.h */,
+				0097BF6813B8286D00D79E81 /* GSWindow.h */,
+			);
+			path = GraphicsServices;
+			sourceTree = "<group>";
+		};
 		08FB7794FE84155DC02AAC07 /* UISpec */ = {
 			isa = PBXGroup;
 			children = (
 				003A2CBB13B3E7090092AD2B /* CoreGraphics.framework */,
 				003A2CB913B3E7010092AD2B /* UIKit.framework */,
+				0097BF5913B8286D00D79E81 /* Private Headers */,
 				C7D4F2B110BDA46900B00019 /* specs */,
 				C76EB5E70F74592C00EF8398 /* src */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
@@ -480,6 +553,20 @@
 				008AFCC013B568DF000A5C00 /* VisibleTouch.h in Headers */,
 				008AFCC113B568DF000A5C00 /* UIEvent+Synthesize.h in Headers */,
 				008AFCC213B568DF000A5C00 /* UITouch+Synthesize.h in Headers */,
+				0097BF6A13B8286D00D79E81 /* GraphicsServices.h in Headers */,
+				0097BF6C13B8286D00D79E81 /* GSBase.h in Headers */,
+				0097BF6E13B8286D00D79E81 /* GSCapability.h in Headers */,
+				0097BF7013B8286D00D79E81 /* GSColor.h in Headers */,
+				0097BF7213B8286D00D79E81 /* GSEvent.h in Headers */,
+				0097BF7413B8286D00D79E81 /* GSFont.h in Headers */,
+				0097BF7613B8286D00D79E81 /* GSGeometry.h in Headers */,
+				0097BF7813B8286D00D79E81 /* GSHeartbeat.h in Headers */,
+				0097BF7A13B8286D00D79E81 /* GSHiccup.h in Headers */,
+				0097BF7C13B8286D00D79E81 /* GSKeyboard.h in Headers */,
+				0097BF7E13B8286D00D79E81 /* GSMainScreen.h in Headers */,
+				0097BF8013B8286D00D79E81 /* GSMaps.h in Headers */,
+				0097BF8213B8286D00D79E81 /* GSStatusBar.h in Headers */,
+				0097BF8413B8286D00D79E81 /* GSWindow.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -530,6 +617,20 @@
 				003A2CB713B3E6E90092AD2B /* VisibleTouch.h in Headers */,
 				003A2ED113B43B6C0092AD2B /* UIEvent+Synthesize.h in Headers */,
 				003A2ED513B43B6C0092AD2B /* UITouch+Synthesize.h in Headers */,
+				0097BF6913B8286D00D79E81 /* GraphicsServices.h in Headers */,
+				0097BF6B13B8286D00D79E81 /* GSBase.h in Headers */,
+				0097BF6D13B8286D00D79E81 /* GSCapability.h in Headers */,
+				0097BF6F13B8286D00D79E81 /* GSColor.h in Headers */,
+				0097BF7113B8286D00D79E81 /* GSEvent.h in Headers */,
+				0097BF7313B8286D00D79E81 /* GSFont.h in Headers */,
+				0097BF7513B8286D00D79E81 /* GSGeometry.h in Headers */,
+				0097BF7713B8286D00D79E81 /* GSHeartbeat.h in Headers */,
+				0097BF7913B8286D00D79E81 /* GSHiccup.h in Headers */,
+				0097BF7B13B8286D00D79E81 /* GSKeyboard.h in Headers */,
+				0097BF7D13B8286D00D79E81 /* GSMainScreen.h in Headers */,
+				0097BF7F13B8286D00D79E81 /* GSMaps.h in Headers */,
+				0097BF8113B8286D00D79E81 /* GSStatusBar.h in Headers */,
+				0097BF8313B8286D00D79E81 /* GSWindow.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -986,6 +1087,7 @@
 				008AFCF713B569A6000A5C00 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "UISpec" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Fixed crash when "gesturing" scroll views
Also added "dummy" categories on UIKit classes to clear compiler warnings when calling private methods.

Fixed a couple of issues on UIQueryScrollView/TableView:
- scrollToBottom went beyond the bottom of the scroll view
- UIQueryTableView is now a subclass of UIQueryScrollView to inherit scrolling methods.
