### PR TITLE
[+] ADD: new scrolling methods that mirror UIAutomation

### DIFF
--- a/src/components/UIQueryScrollView.h
+++ b/src/components/UIQueryScrollView.h
@@ -13,4 +13,15 @@
 -(UIQuery *)scrollDown:(int)offset;
 -(UIQuery *)scrollToBottom;
 
+-(UIQuery *)scrollLeft;
+-(UIQuery *)scrollRight;
+-(UIQuery *)scrollUp;
+-(UIQuery *)scrollDown;
+
+/* UIAutomation API methods unimplemented
+ -(UIQuery *)scrollToElementWithName;
+ -(UIQuery *)scrollToElementWithPredicate;
+ -(UIQuery *)scrollToElementWithValueForKey;
+ */
+
 @end

--- a/src/components/UIQueryScrollView.m
+++ b/src/components/UIQueryScrollView.m
@@ -20,8 +20,40 @@
 	UIScrollView *scroller = (UIScrollView *)self;
     CGFloat scrollerSize = scroller.contentSize.height;
     CGFloat offset = scrollerSize - scroller.frame.size.height;
-	CGPoint bottomOrigin = CGPointMake(0, offset);
-	[scroller setContentOffset: bottomOrigin animated: YES];
+	CGPoint endPoint = CGPointMake(0, offset);
+	[scroller setContentOffset: endPoint animated: YES];
+	return [UIQuery withViews:views className:className];
+}
+
+-(UIQuery *)scrollLeft {
+    UIScrollView *scroller = (UIScrollView *)self;
+    CGFloat offset = scroller.frame.size.width;
+	CGPoint endPoint = CGPointMake(scroller.frame.origin.x - offset, 0);
+	[scroller setContentOffset: endPoint animated: YES];
+	return [UIQuery withViews:views className:className];
+}
+
+-(UIQuery *)scrollRight{
+    UIScrollView *scroller = (UIScrollView *)self;
+    CGFloat offset = scroller.frame.size.width;
+	CGPoint endPoint = CGPointMake(scroller.frame.origin.x + offset, 0);
+	[scroller setContentOffset: endPoint animated: YES];
+	return [UIQuery withViews:views className:className];
+}
+
+-(UIQuery *)scrollUp {
+    UIScrollView *scroller = (UIScrollView *)self;
+    CGFloat offset = scroller.frame.size.height;
+	CGPoint endPoint = CGPointMake(0, scroller.frame.origin.y + offset);
+	[scroller setContentOffset: endPoint animated: YES];
+	return [UIQuery withViews:views className:className];
+}
+
+-(UIQuery *)scrollDown{
+    UIScrollView *scroller = (UIScrollView *)self;
+    CGFloat offset = scroller.frame.size.height;
+	CGPoint endPoint = CGPointMake(0, scroller.frame.origin.y - offset);
+	[scroller setContentOffset: endPoint animated: YES];
 	return [UIQuery withViews:views className:className];
 }
 


### PR DESCRIPTION
Added scrollLeft, scrollRight (and scrollUp, ScrollDown) so a UIScrollView can be scrolled horizontally. Tempted to rename scrollDown:(int)offset to scrollVertically:(int)offset and add scrollHorizontally:(int)offset but that could break existing code...
